### PR TITLE
init metrics reporting to stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ gradlew.bat
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/dictionaries
+.idea/libraries/
 *.iws

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 	testCompile group: 'org.spockframework', name: 'spock-core', version: '1.1-groovy-2.4'
 	integrationTestCompile group: 'org.spockframework', name: 'spock-core', version: '1.1-groovy-2.4'
 	compile 'com.google.code.gson:gson:2.2.4'
-	compile group: 'com.streamr', name: 'client', version: '1.1.1'
+	compile group: 'com.streamr', name: 'client', version: '1.1.2'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ sourceSets {
 }
 
 repositories {
-	mavenCentral()
 	mavenLocal()
+	mavenCentral()
 	// Needed for ethereumj transitive dependency from com.streamr.client
 	maven {
 		url "https://dl.bintray.com/ethereum/maven/"
@@ -55,7 +55,7 @@ dependencies {
 	testCompile group: 'org.spockframework', name: 'spock-core', version: '1.1-groovy-2.4'
 	integrationTestCompile group: 'org.spockframework', name: 'spock-core', version: '1.1-groovy-2.4'
 	compile 'com.google.code.gson:gson:2.2.4'
-	compile group: 'com.streamr', name: 'client', version: '1.1.0'
+	compile group: 'com.streamr', name: 'client', version: '1.1.1'
 }
 
 jar {

--- a/src/integrationTest/groovy/com/streamr/broker/redis/RedisReporterSpec.groovy
+++ b/src/integrationTest/groovy/com/streamr/broker/redis/RedisReporterSpec.groovy
@@ -104,6 +104,9 @@ class RedisReporterSpec extends Specification {
 			void report() {}
 
 			@Override
+			void reportToStream() {}
+
+			@Override
 			void onCassandraWriteError() {}
 
 			@Override

--- a/src/main/java/com/streamr/broker/BrokerProcess.java
+++ b/src/main/java/com/streamr/broker/BrokerProcess.java
@@ -15,6 +15,7 @@ public class BrokerProcess {
 	private final BlockingQueue<StreamMessage> queue;
 	private Stats stats;
 	private int intervalInSec;
+	private int metricsIntervalInSec;
 	private Runnable consumer;
 	private Runnable producer;
 
@@ -22,9 +23,10 @@ public class BrokerProcess {
 		this.queue = new ArrayBlockingQueue<>(queueSize);
 	}
 
-	public void setStats(Stats stats, int intervalInSec) {
+	public void setStats(Stats stats, int intervalInSec, int metricsIntervalInSec) {
 		this.stats = stats;
 		this.intervalInSec = intervalInSec;
+		this.metricsIntervalInSec = metricsIntervalInSec;
 	}
 
 	public void setUpProducer(Function<QueueProducer, Runnable> cb) {
@@ -55,6 +57,9 @@ public class BrokerProcess {
 	public void startStatsLogging() {
 		stats.start(intervalInSec);
 		statsExecutor.scheduleAtFixedRate(stats::report, intervalInSec, intervalInSec, TimeUnit.SECONDS);
+		if (metricsIntervalInSec != -1) {
+			statsExecutor.scheduleAtFixedRate(stats::reportToStream, metricsIntervalInSec, metricsIntervalInSec, TimeUnit.SECONDS);
+		}
 	}
 
 	public void shutdown() {

--- a/src/main/java/com/streamr/broker/Config.java
+++ b/src/main/java/com/streamr/broker/Config.java
@@ -13,6 +13,11 @@ public class Config {
 	public static final String CASSANDRA_PASSWORD = System.getProperty("cassandra.password", "");
 	public static final int QUEUE_SIZE = Integer.parseInt(System.getProperty("queuesize", "200"));
 	public static final int STATS_INTERVAL_IN_SECS = Integer.parseInt(System.getProperty("statsinterval", "30"));
+	public static final int METRICS_INTERVAL_IN_SECS = Integer.parseInt(System.getProperty("metrics.interval", "3"));
+	public static final String METRICS_STREAM_ID = System.getProperty("metrics.stream", "");
+	public static final String METRICS_API_KEY = System.getProperty("metrics.apikey", "");
+	public static final String METRICS_WS_URL = System.getProperty("metrics.wsurl", "ws://localhost:8890/api/v1/ws");
+	public static final String METRICS_REST_URL = System.getProperty("metrics.resturl", "http://localhost:8081/streamr-core/api/v1");
 
 	public static String[] getCassandraHosts() {
 		return CASSANDRA_HOSTS.split(",");

--- a/src/main/java/com/streamr/broker/Main.java
+++ b/src/main/java/com/streamr/broker/Main.java
@@ -11,8 +11,13 @@ public class Main {
 
 	public static void main(String[] args) {
 		BrokerProcess brokerProcess = new BrokerProcess(Config.QUEUE_SIZE);
-		stats = new LoggedStats();
-		brokerProcess.setStats(stats, Config.STATS_INTERVAL_IN_SECS);
+		if (Config.METRICS_STREAM_ID.equals("")) {
+			stats = new LoggedStats();
+		} else {
+			stats = new LoggedStats(Config.METRICS_INTERVAL_IN_SECS, Config.METRICS_STREAM_ID,
+					Config.METRICS_API_KEY, Config.METRICS_WS_URL,Config.METRICS_REST_URL);
+		}
+		brokerProcess.setStats(stats, Config.STATS_INTERVAL_IN_SECS, Config.METRICS_INTERVAL_IN_SECS);
 		brokerProcess.setUpProducer((queueProducer ->
 			new KafkaListener(Config.KAFKA_HOST, Config.KAFKA_GROUP, Config.KAFKA_TOPIC, queueProducer)));
 		brokerProcess.setUpConsumer(

--- a/src/main/java/com/streamr/broker/stats/Stats.java
+++ b/src/main/java/com/streamr/broker/stats/Stats.java
@@ -10,6 +10,7 @@ public interface Stats {
 	void start(int intervalInSec);
 	void stop();
 	void report();
+	void reportToStream();
 
 	void setReservedMessageSemaphores(int reservedMessageSemaphores);
 	void setReservedCassandraSemaphores(int reservedCassandraSemaphores);


### PR DESCRIPTION
The metrics implemented in `data-api` cannot include the traffic that is initiated from `engine-and-editor` since that traffic is directly pushed to Kafka. This PR starts the metrics reporting in the `cloud-broker` to include all traffic.